### PR TITLE
Feat/precompute selectors

### DIFF
--- a/crates/air/src/table.rs
+++ b/crates/air/src/table.rs
@@ -3,10 +3,10 @@ use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 
 use p3_uni_stark::{SymbolicAirBuilder, get_symbolic_constraints};
-use utils::{log2_up, univariate_selectors};
+use utils::log2_up;
 use whir_p3::{
     parameters::{MultivariateParameters, ProtocolParameters},
-    poly::{dense::WhirDensePolynomial, evals::EvaluationsList},
+    poly::evals::EvaluationsList,
     whir::parameters::WhirConfig,
 };
 
@@ -19,7 +19,6 @@ pub struct AirTable<F: Field, EF, A> {
     pub preprocessed_columns: Vec<EvaluationsList<F>>, // TODO 'sparse' preprocessed columns (with non zero values at cylic shifts)
     pub n_constraints: usize,
     pub constraint_degree: usize,
-    pub(crate) univariate_selectors: Vec<WhirDensePolynomial<F>>,
 
     _phantom: std::marker::PhantomData<EF>,
 }
@@ -32,7 +31,7 @@ where
     pub fn new(
         air: A,
         log_length: usize,
-        univariate_skips: usize,
+        _univariate_skips: usize,
         preprocessed_columns: Vec<EvaluationsList<F>>,
         constraint_degree: usize,
     ) -> Self
@@ -49,7 +48,6 @@ where
             preprocessed_columns,
             n_constraints,
             constraint_degree,
-            univariate_selectors: univariate_selectors(univariate_skips),
             _phantom: std::marker::PhantomData,
         }
     }

--- a/crates/air/src/verify.rs
+++ b/crates/air/src/verify.rs
@@ -5,7 +5,10 @@ use p3_symmetric::{CryptographicHasher, PseudoCompressionFunction};
 use serde::{Deserialize, Serialize};
 use sumcheck::{SumcheckComputation, SumcheckError, SumcheckGrinding};
 use tracing::instrument;
-use utils::{ConstraintFolder, fold_multilinear_in_large_field, log2_up};
+use utils::{
+    ConstraintFolder, fold_multilinear_in_large_field, log2_up,
+    univariate::{barycentric_weights_precomputed, evaluate_lagrange_basis_all},
+};
 use whir_p3::{
     fiat_shamir::{errors::ProofError, verifier::VerifierState},
     poly::{evals::EvaluationsList, multilinear::MultilinearPoint},
@@ -111,11 +114,11 @@ impl<
         let witness_up = verifier_state.next_extension_scalars_vec(self.n_witness_columns())?;
         let witness_down = verifier_state.next_extension_scalars_vec(self.n_witness_columns())?;
 
-        let outer_selector_evals = self
-            .univariate_selectors
-            .iter()
-            .map(|s| s.evaluate(outer_sumcheck_challenge.point[0]))
-            .collect::<Vec<_>>();
+        let m = 1 << settings.univariate_skips;
+        let weights = barycentric_weights_precomputed(m);
+        let outer_selector_evals =
+            evaluate_lagrange_basis_all(m, outer_sumcheck_challenge.point[0], &weights);
+
         let preprocessed_up = self
             .preprocessed_columns
             .iter()
@@ -150,12 +153,10 @@ impl<
                 .collect::<Vec<_>>(),
         );
 
-        let zerocheck_selector_evals = self
-            .univariate_selectors
-            .iter()
-            .map(|s| s.evaluate(zerocheck_challenges[0]));
+        let zerocheck_selector_evals =
+            evaluate_lagrange_basis_all(m, zerocheck_challenges[0], &weights);
         if dot_product::<EF, _, _>(
-            zerocheck_selector_evals.clone(),
+            zerocheck_selector_evals.iter().copied(),
             outer_selector_evals.iter().copied(),
         ) * MultilinearPoint(zerocheck_challenges[1..].to_vec()).eq_poly_outside(
             &MultilinearPoint(outer_sumcheck_challenge.point[1..].to_vec()),

--- a/crates/sumcheck/src/prove.rs
+++ b/crates/sumcheck/src/prove.rs
@@ -7,7 +7,10 @@ use rayon::prelude::*;
 use tracing::instrument;
 use utils::{
     batch_fold_multilinear_in_large_field, batch_fold_multilinear_in_small_field,
-    univariate_selectors,
+    univariate::{
+        barycentric_weights_precomputed, evaluate_lagrange_basis_all,
+        evaluate_lagrange_basis_all_base_field,
+    },
 };
 use whir_p3::{
     fiat_shamir::prover::ProverState,
@@ -119,33 +122,35 @@ where
 {
     let eq_mle = eq_factor.map(|eq_factor| EvaluationsList::eval_eq(&eq_factor[1 + round..]));
 
-    let selectors = univariate_selectors::<F>(skips);
+    let m = 1 << skips;
+    let weights = barycentric_weights_precomputed::<F>(m);
 
     let mut p_evals = Vec::<(F, EF)>::new();
     let start = if is_zerofier {
-        p_evals.extend((0..1 << skips).map(|i| (F::from_usize(i), EF::ZERO)));
-        1 << skips
+        p_evals.extend((0..m).map(|i| (F::from_usize(i), EF::ZERO)));
+        m
     } else {
         0
     };
-    for z in start..=comp_degree * ((1 << skips) - 1) {
-        let sum_z = if z == (1 << skips) - 1 {
-            if let Some(eq_factor) = eq_factor {
-                (*sum
-                    - (0..(1 << skips) - 1)
-                        .map(|i| p_evals[i].1 * selectors[i].evaluate(eq_factor[round]))
-                        .sum::<EF>())
-                    / selectors[(1 << skips) - 1].evaluate(eq_factor[round])
+
+    let selector_evals_at_z: Vec<Vec<F>> = (start..=comp_degree * (m - 1))
+        .map(|z| evaluate_lagrange_basis_all_base_field(m, F::from_usize(z), &weights))
+        .collect();
+
+    let selector_evals_at_eq_factor =
+        eq_factor.map(|ef| evaluate_lagrange_basis_all(m, ef[round], &weights));
+
+    for (z_idx, z) in (start..=comp_degree * (m - 1)).enumerate() {
+        let sum_z = if z == m - 1 {
+            if let Some(_eq_factor) = eq_factor {
+                let evals = selector_evals_at_eq_factor.as_ref().unwrap();
+                (*sum - (0..m - 1).map(|i| p_evals[i].1 * evals[i]).sum::<EF>()) / evals[m - 1]
             } else {
                 *sum - p_evals.iter().map(|(_, s)| *s).sum::<EF>()
             }
         } else {
-            let folding_scalars = selectors
-                .iter()
-                .map(|s| s.evaluate(F::from_usize(z)))
-                .collect::<Vec<_>>();
-            // If skips == 1 (ie classic sumcheck round, we could avoid 1 multiplication below: TODO not urgent)
-            let folded = batch_fold_multilinear_in_small_field(multilinears, &folding_scalars);
+            let folding_scalars = &selector_evals_at_z[z_idx];
+            let folded = batch_fold_multilinear_in_small_field(multilinears, folding_scalars);
             let mut sum_z =
                 compute_over_hypercube(&folded, computation, batching_scalars, eq_mle.as_ref());
             if let Some(missing_mul_factor) = missing_mul_factor {
@@ -160,13 +165,14 @@ where
 
     let mut p = WhirDensePolynomial::lagrange_interpolation(&p_evals).unwrap();
 
-    if let Some(eq_factor) = &eq_factor {
+    if let Some(_eq_factor) = &eq_factor {
         // https://eprint.iacr.org/2024/108.pdf Section 3.2
         // We do not take advantage of this trick to send less data, but we could do so in the future (TODO)
+        let evals = selector_evals_at_eq_factor.as_ref().unwrap();
         p *= &WhirDensePolynomial::lagrange_interpolation(
-            &(0..1 << skips)
+            &(0..m)
                 .into_par_iter()
-                .map(|i| (F::from_usize(i), selectors[i].evaluate(eq_factor[round])))
+                .map(|i| (F::from_usize(i), evals[i]))
                 .collect::<Vec<_>>(),
         )
         .unwrap();
@@ -179,25 +185,22 @@ where
     *sum = p.evaluate(challenge);
     *n_vars -= skips;
 
-    let pow_bits = grinding
-        .pow_bits::<EF>((comp_degree + usize::from(eq_factor.is_some())) * ((1 << skips) - 1));
+    let pow_bits =
+        grinding.pow_bits::<EF>((comp_degree + usize::from(eq_factor.is_some())) * (m - 1));
     fs_prover.pow_grinding(pow_bits);
 
-    let folding_scalars = selectors
-        .iter()
-        .map(|s| s.evaluate(challenge))
-        .collect::<Vec<_>>();
-    if let Some(eq_factor) = eq_factor {
+    let selector_evals_at_challenge = evaluate_lagrange_basis_all(m, challenge, &weights);
+    if let Some(_eq_factor) = eq_factor {
+        let evals_at_eq = selector_evals_at_eq_factor.as_ref().unwrap();
         *missing_mul_factor = Some(
-            selectors
-                .iter()
-                .map(|s| s.evaluate(eq_factor[round]) * s.evaluate(challenge))
+            (0..m)
+                .map(|i| evals_at_eq[i] * selector_evals_at_challenge[i])
                 .sum::<EF>()
                 * missing_mul_factor.unwrap_or(EF::ONE),
         );
     }
     // If skips == 1 (ie classic sumcheck round, we could avoid 1 multiplication below: TODO not urgent)
-    batch_fold_multilinear_in_large_field(multilinears, &folding_scalars)
+    batch_fold_multilinear_in_large_field(multilinears, &selector_evals_at_challenge)
 }
 
 fn compute_over_hypercube<F, NF, EF, SC>(

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -13,7 +13,7 @@ p3-air.workspace = true
 p3-matrix.workspace = true
 whir-p3.workspace = true
 tracing.workspace = true
+p3-koala-bear.workspace = true
 
 [dev-dependencies]
-p3-koala-bear.workspace = true
 rand.workspace = true

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -9,7 +9,7 @@ pub use misc::*;
 mod constraints_folder;
 pub use constraints_folder::*;
 
-mod univariate;
+pub mod univariate;
 pub use univariate::*;
 
 mod multilinear;

--- a/crates/utils/src/univariate.rs
+++ b/crates/utils/src/univariate.rs
@@ -1,15 +1,297 @@
-use p3_field::Field;
+use p3_field::{ExtensionField, Field};
 use rayon::prelude::*;
-use whir_p3::poly::dense::WhirDensePolynomial;
 
-pub fn univariate_selectors<F: Field>(n: usize) -> Vec<WhirDensePolynomial<F>> {
-    (0..1 << n)
-        .into_par_iter()
+/// Precomputed barycentric weights for common skip values
+/// These are the weights for Lagrange interpolation on {0, 1, ..., m-1}
+/// where m = 2^skips for skips = 1, 2, 3, 4
+
+// For skips=1, m=2: weights for {0, 1}
+const BARYCENTRIC_WEIGHTS_2: [u64; 2] = [2130706432, 1];
+
+// For skips=2, m=4: weights for {0, 1, 2, 3}
+const BARYCENTRIC_WEIGHTS_4: [u64; 4] = [1775588694, 1065353217, 1065353216, 355117739];
+
+// For skips=3, m=8: weights for {0, 1, 2, ..., 7}
+const BARYCENTRIC_WEIGHTS_8: [u64; 8] = [
+    413035751, 1370162609, 150925039, 458693746, 1672012687, 1979781394, 760543824, 1717670682,
+];
+
+// For skips=4, m=16: weights for {0, 1, 2, ..., 15}
+const BARYCENTRIC_WEIGHTS_16: [u64; 16] = [
+    1296489123, 1859727485, 1896852636, 303130976, 1221313505, 1574523155, 926972130, 938885123,
+    1191821310, 1203734303, 556183278, 909392928, 1827575457, 233853797, 270978948, 834217310,
+];
+
+// ================================================================================================
+// FUNCTIONS - Barycentric Lagrange evaluation (optimized approach)
+// ================================================================================================
+
+/// Compute barycentric weights for Lagrange interpolation on points {0, 1, ..., m-1}
+/// Weight for point i is: w_i = (-1)^(m-1-i) / (i! * (m-1-i)!)
+pub fn barycentric_weights<F: Field>(m: usize) -> Vec<F> {
+    if m == 1 {
+        return vec![F::ONE];
+    }
+
+    // Compute factorials
+    let mut factorial = vec![F::ONE; m];
+    for i in 1..m {
+        factorial[i] = factorial[i - 1] * F::from_usize(i);
+    }
+
+    (0..m)
         .map(|i| {
-            let values = (0..1 << n)
-                .map(|j| (F::from_u64(j), if i == j { F::ONE } else { F::ZERO }))
-                .collect::<Vec<_>>();
-            WhirDensePolynomial::lagrange_interpolation(&values).unwrap()
+            let sign = if (m - 1 - i) % 2 == 0 {
+                F::ONE
+            } else {
+                -F::ONE
+            };
+            sign / (factorial[i] * factorial[m - 1 - i])
         })
         .collect()
+}
+
+/// Get precomputed barycentric weights for common values, fallback to computation
+pub fn barycentric_weights_precomputed<F: Field + 'static>(m: usize) -> Vec<F> {
+    use std::any::TypeId;
+
+    if TypeId::of::<F>() == TypeId::of::<p3_koala_bear::KoalaBear>() {
+        match m {
+            2 => BARYCENTRIC_WEIGHTS_2
+                .iter()
+                .map(|&w| F::from_u64(w))
+                .collect(),
+            4 => BARYCENTRIC_WEIGHTS_4
+                .iter()
+                .map(|&w| F::from_u64(w))
+                .collect(),
+            8 => BARYCENTRIC_WEIGHTS_8
+                .iter()
+                .map(|&w| F::from_u64(w))
+                .collect(),
+            16 => BARYCENTRIC_WEIGHTS_16
+                .iter()
+                .map(|&w| F::from_u64(w))
+                .collect(),
+            _ => barycentric_weights::<F>(m),
+        }
+    } else {
+        barycentric_weights::<F>(m)
+    }
+}
+
+/// Method for evaluating Lagrange basis polynomials without constructing
+/// the full polynomial coefficients. It relies on the second form of the barycentric
+/// interpolation formula.
+///
+/// For a set of points {x_0, ..., x_{m-1}}, the Lagrange basis polynomial L_i(x) can be
+/// evaluated as:
+///
+/// L_i(x) = l(x) * w_i / (x - x_i)
+///
+/// where:
+/// - l(x) = ∏(x - x_j) is the "vanishing polynomial" over the grid.
+/// - w_i = 1 / ∏_{j≠i}(x_i - x_j) are the precomputed barycentric weights.
+///
+/// This approach reduces the complexity of evaluation from O(m^2) (for interpolation)
+/// followed by O(m) (for evaluation) to just O(m) per evaluation after a one-time
+/// O(m) setup for the weights.
+///
+/// For a detailed explanation of the formula and its derivation, see:
+/// https://tobydriscoll.net/fnc-julia/globalapprox/barycentric.html
+///
+/// Evaluate all Lagrange basis polynomials L_i(x) at point x for grid {0, 1, ..., m-1}
+/// Returns [L_0(x), L_1(x), ..., L_{m-1}(x)]
+///
+// TODO: Should we use the Montgomery trick here instead of suffix prefix?
+/// Helper function to compute prefix and suffix products for Lagrange basis evaluation
+/// Returns (prefix_products, suffix_products) where:
+/// - prefix_products[k] = ∏_{j < k} (x - j)  with prefix_products[0] = 1
+/// - suffix_products[k] = ∏_{j > k} (x - j)  with suffix_products[m] = 1
+#[allow(dead_code)]
+fn compute_prefix_suffix_products<T: Field>(m: usize, x: T) -> (Vec<T>, Vec<T>) {
+    let denom: Vec<T> = (0..m).map(|j| x - T::from_usize(j)).collect();
+
+    let mut pref = vec![T::ONE; m + 1];
+    for k in 0..m {
+        pref[k + 1] = pref[k] * denom[k];
+    }
+
+    let mut suff = vec![T::ONE; m + 1];
+    for k in (0..m).rev() {
+        suff[k] = suff[k + 1] * denom[k];
+    }
+    (pref, suff)
+}
+
+#[allow(dead_code)]
+fn evaluate_lagrange_basis_prefix_suffix<F: Field, T: Field>(
+    m: usize,
+    x: T,
+    weights: &[F],
+) -> Vec<T>
+where
+    T: From<F>,
+{
+    let (pref, suff) = compute_prefix_suffix_products(m, x);
+    let mut result = vec![T::ZERO; m];
+    for i in 0..m {
+        let product = pref[i] * suff[i + 1];
+        result[i] = product * T::from(weights[i]);
+    }
+    result
+}
+
+///  Montgomery's Trick Implementation
+
+/// This method uses one field inversion, which can be faster if m is large.
+fn evaluate_lagrange_basis_montgomery<F: Field, T: Field>(m: usize, x: T, weights: &[F]) -> Vec<T>
+where
+    T: From<F>,
+{
+    let denom: Vec<T> = (0..m).map(|j| x - T::from_usize(j)).collect();
+
+    // 1. Compute prefix products: pref[i] = d_0 * ... * d_i
+    let mut pref = vec![T::ONE; m];
+    pref[0] = denom[0];
+    for i in 1..m {
+        pref[i] = pref[i - 1] * denom[i];
+    }
+
+    // 2. Compute the inverse of the total product (one inversion)
+    let mut inv_suffix = pref[m - 1].inverse();
+    let mut result = vec![T::ZERO; m];
+
+    // 3. Iterate backwards to compute each L_i(x)
+    for i in (1..m).rev() {
+        // For index i, we need: pref[i-1] * (d_{i+1} * ... * d_{m-1})
+        // The suffix part is pref[m-1] * (d_0 * ... * d_i)⁻¹ = pref[m-1] * inv_suffix
+        let prefix_part = pref[i - 1];
+        let suffix_part = pref[m - 1] * inv_suffix;
+        let product = prefix_part * suffix_part;
+        result[i] = product * T::from(weights[i]);
+
+        // Update inv_suffix for the next iteration (i-1)
+        // inv_suffix for (i-1) = (d_0 * ... * d_{i-1})⁻¹ = inv_suffix * d_i
+        inv_suffix *= denom[i];
+    }
+
+    // Handle the i=0 case separately
+    // We need d_1 * ... * d_{m-1} = pref[m-1] * d_0⁻¹
+    // At this point, inv_suffix is exactly d_0⁻¹
+    let product_zero = pref[m - 1] * inv_suffix;
+    result[0] = product_zero * T::from(weights[0]);
+
+    result
+}
+
+/// Evaluate all Lagrange basis polynomials L_i(x) at point x in an extension field.
+pub fn evaluate_lagrange_basis_all<F: Field, EF: ExtensionField<F>>(
+    m: usize,
+    x: EF,
+    weights: &[F],
+) -> Vec<EF> {
+    if m == 1 {
+        return vec![EF::ONE];
+    }
+    if let Some(i) = (0..m).find(|&i| x == EF::from_usize(i)) {
+        let mut result = vec![EF::ZERO; m];
+        result[i] = EF::ONE;
+        return result;
+    }
+
+    // Method 1: Prefix-Suffix (clearer, more multiplications)
+    //evaluate_lagrange_basis_prefix_suffix(m, x, weights)
+
+    // Method 2: Montgomery's Trick (fewer multiplications, one inversion)
+    evaluate_lagrange_basis_montgomery(m, x, weights)
+}
+
+/// Evaluate all Lagrange basis polynomials L_i(x) at point x in the base field.
+pub fn evaluate_lagrange_basis_all_base_field<F: Field>(m: usize, x: F, weights: &[F]) -> Vec<F> {
+    if m == 1 {
+        return vec![F::ONE];
+    }
+    if let Some(i) = (0..m).find(|&i| x == F::from_usize(i)) {
+        let mut result = vec![F::ZERO; m];
+        result[i] = F::ONE;
+        return result;
+    }
+
+    // Method 1: Prefix-Suffix (clearer, more multiplications)
+    //evaluate_lagrange_basis_prefix_suffix(m, x, weights)
+
+    // Method 2: Montgomery's Trick (fewer multiplications, one inversion)
+    evaluate_lagrange_basis_montgomery(m, x, weights)
+}
+
+/// Efficient evaluation of selector polynomials at multiple points in parallel.
+pub fn evaluate_selectors_batch<F: Field, EF: ExtensionField<F>>(
+    m: usize,
+    points: &[EF],
+) -> Vec<Vec<EF>> {
+    let weights = barycentric_weights_precomputed::<F>(m);
+    points
+        .par_iter()
+        .map(|&point| evaluate_lagrange_basis_all(m, point, &weights))
+        .collect()
+}
+
+#[cfg(all(test))]
+mod tests {
+    use super::barycentric_weights;
+    use p3_field::PrimeField64;
+    use p3_koala_bear::KoalaBear;
+
+    type F = KoalaBear;
+
+    // Test to generate precomputed barycentric weights
+    #[test]
+    fn print_precomputed_barycentric_weights() {
+        println!("\n=== BARYCENTRIC WEIGHTS FOR KOALABEAR ===");
+
+        for skips in 1..=4 {
+            let m = 1usize << skips;
+            let weights = barycentric_weights::<F>(m);
+
+            println!(
+                "\n// For skips={}, m={}: weights for {{0, 1, ..., {}}}",
+                skips,
+                m,
+                m - 1
+            );
+            print!("const BARYCENTRIC_WEIGHTS_{}: [u64; {}] = [", m, m);
+
+            for (i, weight) in weights.iter().enumerate() {
+                if i > 0 {
+                    print!(", ");
+                }
+                if i % 8 == 0 && m > 8 {
+                    print!("\n    ");
+                }
+                print!("{}", weight.as_canonical_u64());
+            }
+
+            if m > 8 {
+                println!("\n];");
+            } else {
+                println!("];");
+            }
+
+            println!("// Verification: (skipped for now - trait issues)")
+        }
+    }
+
+    // Test to verify barycentric evaluation matches polynomial evaluation
+    #[test]
+    fn verify_barycentric_vs_polynomial_evaluation() {
+        println!("\n=== VERIFICATION: BARYCENTRIC vs POLYNOMIAL ===");
+
+        for skips in 1..=4 {
+            let m = 1usize << skips;
+            println!("\nTesting skips={}, m={}", skips, m);
+
+            println!("// Comparison test: (skipped for now - trait issues)")
+        }
+    }
 }

--- a/crates/utils/src/univariate.rs
+++ b/crates/utils/src/univariate.rs
@@ -22,10 +22,6 @@ const BARYCENTRIC_WEIGHTS_16: [u64; 16] = [
     1191821310, 1203734303, 556183278, 909392928, 1827575457, 233853797, 270978948, 834217310,
 ];
 
-// ================================================================================================
-// FUNCTIONS - Barycentric Lagrange evaluation (optimized approach)
-// ================================================================================================
-
 /// Compute barycentric weights for Lagrange interpolation on points {0, 1, ..., m-1}
 /// Weight for point i is: w_i = (-1)^(m-1-i) / (i! * (m-1-i)!)
 pub fn barycentric_weights<F: Field>(m: usize) -> Vec<F> {


### PR DESCRIPTION
This PR precomputes selector barycentric weights (m=2,4,8,16) and switches selector evaluation from dense Lagrange polynomials to on‑the‑fly barycentric evaluation using a single‑inversion Montgomery trick