### PR TITLE
Change eval points

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,3 +155,11 @@ utils = { path = "crates/utils" }
 [[bench]]
 name = "folding_benchmarks"
 harness = false
+
+[[bench]]
+name = "poseidon2_benchmark"
+harness = false
+
+[[bench]]
+name = "sumcheck_timings"
+harness = false

--- a/benches/poseidon2_benchmark.rs
+++ b/benches/poseidon2_benchmark.rs
@@ -7,7 +7,6 @@ use whirlaway::examples::poseidon2::prove_poseidon2;
 fn poseidon2_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("poseidon2_protocol");
 
-    // Configurar para solo 10 muestras para que sea más rápido
     group.sample_size(30);
 
     group.bench_function("complete_protocol", |b| {
@@ -16,7 +15,7 @@ fn poseidon2_benchmark(c: &mut Criterion) {
             let benchmark = prove_poseidon2(
                 log_n_rows,
                 AirSettings::new(
-                    0, // SECURITY_BITS: disable grinding for clean timing
+                    128,
                     SecurityAssumption::CapacityBound,
                     FoldingFactor::ConstantFromSecondRound(7, 4),
                     log_inv_rate,
@@ -24,7 +23,7 @@ fn poseidon2_benchmark(c: &mut Criterion) {
                     5,
                 ),
                 0,
-                false, // Sin logs para evitar conflictos
+                false,
             );
             black_box(benchmark);
         });

--- a/benches/poseidon2_benchmark.rs
+++ b/benches/poseidon2_benchmark.rs
@@ -1,0 +1,37 @@
+use air::AirSettings;
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use whir_p3::parameters::{FoldingFactor, errors::SecurityAssumption};
+
+use whirlaway::examples::poseidon2::prove_poseidon2;
+
+fn poseidon2_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("poseidon2_protocol");
+
+    // Configurar para solo 10 muestras para que sea más rápido
+    group.sample_size(30);
+
+    group.bench_function("complete_protocol", |b| {
+        b.iter(|| {
+            let (log_n_rows, log_inv_rate) = (18, 1);
+            let benchmark = prove_poseidon2(
+                log_n_rows,
+                AirSettings::new(
+                    0, // SECURITY_BITS: disable grinding for clean timing
+                    SecurityAssumption::CapacityBound,
+                    FoldingFactor::ConstantFromSecondRound(7, 4),
+                    log_inv_rate,
+                    4,
+                    5,
+                ),
+                0,
+                false, // Sin logs para evitar conflictos
+            );
+            black_box(benchmark);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, poseidon2_benchmark);
+criterion_main!(benches);

--- a/benches/sumcheck_timings.rs
+++ b/benches/sumcheck_timings.rs
@@ -10,7 +10,7 @@ use whirlaway::examples::poseidon2::prove_poseidon2;
 
 const LOG_N_ROWS: usize = 18;
 const LOG_INV_RATE: usize = 1;
-const SECURITY_BITS: usize = 0; // disable grinding for clean timings
+const SECURITY_BITS: usize = 128;
 const UNIVARIATE_SKIPS: usize = 4;
 
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/benches/sumcheck_timings.rs
+++ b/benches/sumcheck_timings.rs
@@ -1,0 +1,183 @@
+use air::AirSettings;
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+use tracing::Subscriber;
+use tracing_subscriber::{Layer, Registry, layer::Context, prelude::*, registry::LookupSpan};
+
+use whir_p3::parameters::{FoldingFactor, errors::SecurityAssumption};
+use whirlaway::examples::poseidon2::prove_poseidon2;
+
+const LOG_N_ROWS: usize = 18;
+const LOG_INV_RATE: usize = 1;
+const SECURITY_BITS: usize = 0; // disable grinding for clean timings
+const UNIVARIATE_SKIPS: usize = 4;
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum PhaseTag {
+    None,
+    Zerocheck,
+    Inner,
+}
+
+struct SpanData {
+    start: Option<Instant>,
+    phase: PhaseTag,
+}
+
+struct Accumulators {
+    zerocheck_ns: AtomicU64,
+    inner_ns: AtomicU64,
+}
+
+impl Accumulators {
+    fn new() -> Self {
+        Self {
+            zerocheck_ns: AtomicU64::new(0),
+            inner_ns: AtomicU64::new(0),
+        }
+    }
+
+    fn take_zerocheck(&self) -> Duration {
+        let ns = self.zerocheck_ns.swap(0, Ordering::Relaxed);
+        Duration::from_nanos(ns)
+    }
+
+    fn take_inner(&self) -> Duration {
+        let ns = self.inner_ns.swap(0, Ordering::Relaxed);
+        Duration::from_nanos(ns)
+    }
+}
+
+thread_local! {
+    static CURRENT_PHASE: std::cell::Cell<PhaseTag> = std::cell::Cell::new(PhaseTag::None);
+}
+
+struct SumcheckTimingLayer {
+    acc: std::sync::Arc<Accumulators>,
+}
+
+impl SumcheckTimingLayer {
+    fn new() -> (Self, std::sync::Arc<Accumulators>) {
+        let acc = std::sync::Arc::new(Accumulators::new());
+        (Self { acc: acc.clone() }, acc)
+    }
+}
+
+impl<S> Layer<S> for SumcheckTimingLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: Context<'_, S>,
+    ) {
+        if let Some(span) = ctx.span(id) {
+            let meta = attrs.metadata();
+            if meta.name() == "sumcheck_round" {
+                let mut ext = span.extensions_mut();
+                ext.insert(SpanData {
+                    start: None,
+                    phase: PhaseTag::None,
+                });
+            }
+        }
+    }
+
+    fn on_enter(&self, id: &tracing::span::Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let meta = span.metadata();
+            match meta.name() {
+                "zerocheck" => CURRENT_PHASE.with(|p| p.set(PhaseTag::Zerocheck)),
+                "inner sumchecks" => CURRENT_PHASE.with(|p| p.set(PhaseTag::Inner)),
+                "sumcheck_round" => {
+                    let mut ext = span.extensions_mut();
+                    if let Some(data) = ext.get_mut::<SpanData>() {
+                        data.phase = CURRENT_PHASE.with(|p| p.get());
+                        data.start = Some(Instant::now());
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn on_exit(&self, id: &tracing::span::Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let meta = span.metadata();
+            match meta.name() {
+                "zerocheck" | "inner sumchecks" => CURRENT_PHASE.with(|p| p.set(PhaseTag::None)),
+                "sumcheck_round" => {
+                    let mut ext = span.extensions_mut();
+                    if let Some(data) = ext.get_mut::<SpanData>() {
+                        if let Some(start) = data.start.take() {
+                            let dur = start.elapsed().as_nanos() as u64;
+                            match data.phase {
+                                PhaseTag::Zerocheck => {
+                                    self.acc.zerocheck_ns.fetch_add(dur, Ordering::Relaxed);
+                                }
+                                PhaseTag::Inner => {
+                                    self.acc.inner_ns.fetch_add(dur, Ordering::Relaxed);
+                                }
+                                PhaseTag::None => {}
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+pub fn sumcheck_timings_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sumcheck_timings");
+    group
+        .sample_size(20)
+        .warm_up_time(Duration::from_secs(3))
+        .measurement_time(Duration::from_secs(20));
+
+    let settings = AirSettings::new(
+        SECURITY_BITS,
+        SecurityAssumption::CapacityBound,
+        FoldingFactor::ConstantFromSecondRound(7, 4),
+        LOG_INV_RATE,
+        UNIVARIATE_SKIPS,
+        5,
+    );
+
+    group.bench_function(BenchmarkId::new("zerocheck_only", LOG_N_ROWS), |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                let (layer, acc) = SumcheckTimingLayer::new();
+                tracing::subscriber::with_default(Registry::default().with(layer), || {
+                    let _ = prove_poseidon2(LOG_N_ROWS, settings.clone(), 0, false);
+                });
+                total += acc.take_zerocheck();
+            }
+            black_box(total)
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("inner_only", LOG_N_ROWS), |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                let (layer, acc) = SumcheckTimingLayer::new();
+                tracing::subscriber::with_default(Registry::default().with(layer), || {
+                    let _ = prove_poseidon2(LOG_N_ROWS, settings.clone(), 0, false);
+                });
+                total += acc.take_inner();
+            }
+            black_box(total)
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, sumcheck_timings_bench);
+criterion_main!(benches);

--- a/crates/air/src/lib.rs
+++ b/crates/air/src/lib.rs
@@ -6,7 +6,7 @@ mod uni_skip_utils;
 mod utils;
 mod verify;
 
-const WHIR_POW_BITS: usize = 16;
+const WHIR_POW_BITS: usize = 0;
 
 use whir_p3::parameters::{FoldingFactor, errors::SecurityAssumption};
 

--- a/crates/air/src/lib.rs
+++ b/crates/air/src/lib.rs
@@ -6,7 +6,7 @@ mod uni_skip_utils;
 mod utils;
 mod verify;
 
-const WHIR_POW_BITS: usize = 8; // Reduced from 16 for less variation
+const WHIR_POW_BITS: usize = 16;
 
 use whir_p3::parameters::{FoldingFactor, errors::SecurityAssumption};
 

--- a/crates/air/src/lib.rs
+++ b/crates/air/src/lib.rs
@@ -6,7 +6,7 @@ mod uni_skip_utils;
 mod utils;
 mod verify;
 
-const WHIR_POW_BITS: usize = 16;
+const WHIR_POW_BITS: usize = 8; // Reduced from 16 for less variation
 
 use whir_p3::parameters::{FoldingFactor, errors::SecurityAssumption};
 

--- a/crates/air/src/lib.rs
+++ b/crates/air/src/lib.rs
@@ -6,7 +6,7 @@ mod uni_skip_utils;
 mod utils;
 mod verify;
 
-const WHIR_POW_BITS: usize = 0;
+const WHIR_POW_BITS: usize = 16;
 
 use whir_p3::parameters::{FoldingFactor, errors::SecurityAssumption};
 

--- a/crates/air/src/prove.rs
+++ b/crates/air/src/prove.rs
@@ -1,7 +1,8 @@
 use p3_air::Air;
 use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{
-    BasedVectorSpace, ExtensionField, Field, Packable, TwoAdicField, cyclic_subgroup_known_order,
+    BasedVectorSpace, ExtensionField, Field, Packable, PrimeField64, TwoAdicField,
+    cyclic_subgroup_known_order,
 };
 use p3_symmetric::{CryptographicHasher, PseudoCompressionFunction};
 use p3_util::log2_strict_usize;
@@ -39,7 +40,7 @@ cf https://eprint.iacr.org/2023/552.pdf and https://solvable.group/posts/super-a
 
 impl<F, EF, A> AirTable<F, EF, A>
 where
-    F: TwoAdicField,
+    F: TwoAdicField + PrimeField64,
     EF: ExtensionField<F> + TwoAdicField,
     A: for<'a> Air<ConstraintFolder<'a, F, F, EF>>
         + for<'a> Air<ConstraintFolder<'a, F, EF, EF>>

--- a/crates/sumcheck/src/prove.rs
+++ b/crates/sumcheck/src/prove.rs
@@ -16,9 +16,6 @@ use whir_p3::{
 
 use crate::{SumcheckComputation, SumcheckComputationPacked, SumcheckGrinding};
 
-// const FIELD_HALF_U32: u32 = 1065353217; // 1/2 in KoalaBear
-const FIELD_QUARTER_U32: u32 = 1598029825; // 1/4 in KoalaBear  
-
 pub const MIN_VARS_FOR_GPU: usize = 0; // When there are a small number of variables, it's not worth using GPU
 
 #[allow(clippy::too_many_arguments)]
@@ -134,45 +131,23 @@ where
             // eq(1/2, 1) = 1/2 * 1 + 0 * 1/2 = 1/2
             //
             // Since this is symmetric, we can compute h(1/2) more efficiently.
-            // Two cases:
-            //  - Linear in z: if h(z) = ∑_b f(z, b) with f linear in z, then
-            //      h(1/2) = 1/2 * ∑_b (f(0, b) + f(1, b)).
-            //  - Product (this case): if h(z) = ∑_b p(z, b) * q(z, b) with p,q lineal en z, then
+            // In our case since we have a product of linear polynomials, we can compute h(1/2) as:
+            // h(z) = ∑_b p(z, b) * q(z, b) with p,q linear in z, then
             //      h(1/2) = 1/4 * ∑_b (p(0, b) + p(1, b)) * (q(0, b) + q(1, b)).
             //  This yields only one multiplication per hypercube element instead of three evaluations at {0,1,2}.
 
-            // Calculate h(0) - evaluate at z = 0
-            let h0 = {
-                let folding_scalars: Vec<_> =
-                    selectors.iter().map(|s| s.evaluate(F::ZERO)).collect();
-                let folded = batch_fold_multilinear_in_small_field(multilinears, &folding_scalars);
-                let mut h =
-                    compute_over_hypercube(&folded, computation, batching_scalars, eq_mle.as_ref());
-                if let Some(missing_mul_factor) = missing_mul_factor {
-                    h *= *missing_mul_factor;
-                }
-                h
-            };
+            let folding_scalars_0: Vec<_> = selectors.iter().map(|s| s.evaluate(F::ZERO)).collect();
+            let folding_scalars_1: Vec<_> = selectors.iter().map(|s| s.evaluate(F::ONE)).collect();
+
+            let folded_0 = batch_fold_multilinear_in_small_field(multilinears, &folding_scalars_0);
+            let folded_1 = batch_fold_multilinear_in_small_field(multilinears, &folding_scalars_1);
+
+            // Calculate h(0)
+            let h0 =
+                compute_over_hypercube(&folded_0, computation, batching_scalars, eq_mle.as_ref());
 
             // Derive h(1) from the constraint: h(1) = total_sum - h(0)
             let h1 = *sum - h0;
-
-            // Fold multilinears at z = 0 to get f(0, b) for all b
-            let folded_0 = batch_fold_multilinear_in_small_field(
-                multilinears,
-                &selectors
-                    .iter()
-                    .map(|s| s.evaluate(F::ZERO))
-                    .collect::<Vec<_>>(),
-            );
-            // Fold multilinears at z = 1 to get f(1, b) for all b
-            let folded_1 = batch_fold_multilinear_in_small_field(
-                multilinears,
-                &selectors
-                    .iter()
-                    .map(|s| s.evaluate(F::ONE))
-                    .collect::<Vec<_>>(),
-            );
 
             // Sum f(0, b) + f(1, b) for all b
             let summed_multilinears: Vec<_> = folded_0
@@ -188,57 +163,39 @@ where
                 batching_scalars,
                 eq_mle.as_ref(),
             );
-            h_half *= EF::from(F::from_u32(FIELD_QUARTER_U32));
-            if let Some(missing_mul_factor) = missing_mul_factor {
-                h_half *= *missing_mul_factor;
-            }
+            // Multiply by 1/4 using two-adic division for clarity/consistency
+            h_half *= EF::from(F::ONE.div_2exp_u64(2));
 
-            // Verify that our derivation is correct: h(0) + h(1) should equal total_sum
-            // Since h(1) = total_sum - h(0), this should always be zero
-            // TODO: check if we can remove this check
-            // debug_assert!(
-            //     (h0 + h1 - *sum).is_zero(),
-            //     "Derivation error: h(0) + h(1) != total_sum"
-            // );
+            // Instead of sending h(0), h(1), h(1/2) and interpolating, we compute
+            // the quadratic coefficients [a0, a1, a2] directly from the known values.
+            //
+            // Given the quadratic polynomial p(z) = a0 + a1*z + a2*z**2, we know:
+            //   p(0) = h0      (evaluated at z = 0)
+            //   p(1) = h1      (evaluated at z = 1)
+            //   p(1/2) = h_half (evaluated at z = 1/2)
+            //
+            // Solving the system of equations yields:
+            //   a0 = h0
+            //   a2 = 2*(h0 + h1 - 2*h_half)
+            //   a1 = h1 - a0 - a2
 
-            // Send polynomial coefficients [a0, a1, a2] directly instead of values
-            // at z in {0, 1, 1/2}.
-
-            // Reconstruct quadratic coefficients directly solving the system of equations:
-            // a0 = h(0) = h0
-            // a1 = 4*h(1/2) - h(1) - 3*h(0)
-            // a2 = 2*h(1) + 2*h(0) - 4*h(1/2)
-
-            // TODO: use constants
-            let four = EF::from_usize(4);
-            let three = EF::from_usize(3);
-            let two = EF::from_usize(2);
             let a0 = h0;
-            let a1 = four * h_half - h1 - three * h0;
-            let a2 = two * h1 + two * h0 - four * h_half;
+            let a2 = (h0 + h1 - h_half.double()).double();
+            let a1 = h1 - a0 - a2;
 
             fs_prover.add_extension_scalars(&[a0, a1, a2]);
             let challenge = fs_prover.sample();
             challenges.push(challenge);
-            let p_at_challenge = a0 + a1 * challenge + a2 * (challenge * challenge);
+
+            // Use Horner's method for efficient polynomial evaluation: (a2*x + a1)*x + a0
+            let p_at_challenge = (a2 * challenge + a1) * challenge + a0;
             *sum = p_at_challenge;
 
             *n_vars -= skips;
-            let pow_bits = grinding.pow_bits::<EF>(
-                (comp_degree + usize::from(eq_factor.is_some())) * ((1 << skips) - 1),
-            );
+            let pow_bits = grinding.pow_bits::<EF>(comp_degree);
             fs_prover.pow_grinding(pow_bits);
 
             let folding_scalars: Vec<_> = selectors.iter().map(|s| s.evaluate(challenge)).collect();
-            if let Some(eq_factor) = eq_factor {
-                *missing_mul_factor = Some(
-                    selectors
-                        .iter()
-                        .map(|s| s.evaluate(eq_factor[round]) * s.evaluate(challenge))
-                        .sum::<EF>()
-                        * missing_mul_factor.unwrap_or(EF::ONE),
-                );
-            }
             batch_fold_multilinear_in_large_field(multilinears, &folding_scalars)
         }
         _ => {
@@ -404,14 +361,3 @@ where
     let res = computation.eval(point, batching_scalars);
     eq_mle_eval.map_or(res, |factor| res * factor)
 }
-
-// Delete before merging
-// Notes: For cubic polynomials (degree 3) with skips = 1, we could use 4 points
-// to avoid Lagrange interpolation by solving the system directly:
-//
-// Using points {0, 1, 1/2, -1} and evaluations {h0, h1, h_half, h_minus_one}:
-//
-// a0 = h0
-// a2 = 1/2 * (h_minus_one + h1 - 2*a0)
-// a3 = -1/3 * (8*h_half - 4*(h0 + h1) + 2*a2)
-// a1 = h1 - h0 - (a2 + a3)

--- a/crates/sumcheck/src/prove.rs
+++ b/crates/sumcheck/src/prove.rs
@@ -16,7 +16,7 @@ use whir_p3::{
 
 use crate::{SumcheckComputation, SumcheckComputationPacked, SumcheckGrinding};
 
-const FIELD_HALF_U32: u32 = 1065353217; // 1/2 in KoalaBear
+// const FIELD_HALF_U32: u32 = 1065353217; // 1/2 in KoalaBear
 const FIELD_QUARTER_U32: u32 = 1598029825; // 1/4 in KoalaBear  
 
 pub const MIN_VARS_FOR_GPU: usize = 0; // When there are a small number of variables, it's not worth using GPU
@@ -133,13 +133,13 @@ where
             // eq(1/2, 0) = 1/2 * 0 + (1 - 1/2) * 1 = 1/2
             // eq(1/2, 1) = 1/2 * 1 + 0 * 1/2 = 1/2
             //
-            // Since this is symmetric, we can compute h(1/2) more efficiently:
-            // h(1/2) = ∑_b f(1/2, b)
-            //        = ∑_b (eq(1/2, 0) * f(0, b) + eq(1/2, 1) * f(1, b))
-            //        = ∑_b (1/2 * f(0, b) + 1/2 * f(1, b))
-            //        = 1/4 * ∑_b (f(0, b) + f(1, b))
-            //
-            //  We only need 1 evaluation per hypercube element instead of 3
+            // Since this is symmetric, we can compute h(1/2) more efficiently.
+            // Two cases:
+            //  - Linear in z: if h(z) = ∑_b f(z, b) with f linear in z, then
+            //      h(1/2) = 1/2 * ∑_b (f(0, b) + f(1, b)).
+            //  - Product (this case): if h(z) = ∑_b p(z, b) * q(z, b) with p,q lineal en z, then
+            //      h(1/2) = 1/4 * ∑_b (p(0, b) + p(1, b)) * (q(0, b) + q(1, b)).
+            //  This yields only one multiplication per hypercube element instead of three evaluations at {0,1,2}.
 
             // Calculate h(0) - evaluate at z = 0
             let h0 = {
@@ -201,19 +201,27 @@ where
             //     "Derivation error: h(0) + h(1) != total_sum"
             // );
 
-            // Send h(0), h(1), and h(1/2) directly instead of polynomial coefficients
-            fs_prover.add_extension_scalars(&[h0, h1, h_half]);
+            // Send polynomial coefficients [a0, a1, a2] directly instead of values
+            // at z in {0, 1, 1/2}.
 
-            let p = WhirDensePolynomial::lagrange_interpolation(&[
-                (F::ZERO, h0),
-                (F::ONE, h1),
-                (F::from_u32(FIELD_HALF_U32), h_half),
-            ])
-            .unwrap();
+            // Reconstruct quadratic coefficients directly solving the system of equations:
+            // a0 = h(0) = h0
+            // a1 = 4*h(1/2) - h(1) - 3*h(0)
+            // a2 = 2*h(1) + 2*h(0) - 4*h(1/2)
 
+            // TODO: use constants
+            let four = EF::from_usize(4);
+            let three = EF::from_usize(3);
+            let two = EF::from_usize(2);
+            let a0 = h0;
+            let a1 = four * h_half - h1 - three * h0;
+            let a2 = two * h1 + two * h0 - four * h_half;
+
+            fs_prover.add_extension_scalars(&[a0, a1, a2]);
             let challenge = fs_prover.sample();
             challenges.push(challenge);
-            *sum = p.evaluate(challenge);
+            let p_at_challenge = a0 + a1 * challenge + a2 * (challenge * challenge);
+            *sum = p_at_challenge;
 
             *n_vars -= skips;
             let pow_bits = grinding.pow_bits::<EF>(
@@ -396,3 +404,14 @@ where
     let res = computation.eval(point, batching_scalars);
     eq_mle_eval.map_or(res, |factor| res * factor)
 }
+
+// Delete before merging
+// Notes: For cubic polynomials (degree 3) with skips = 1, we could use 4 points
+// to avoid Lagrange interpolation by solving the system directly:
+//
+// Using points {0, 1, 1/2, -1} and evaluations {h0, h1, h_half, h_minus_one}:
+//
+// a0 = h0
+// a2 = 1/2 * (h_minus_one + h1 - 2*a0)
+// a3 = -1/3 * (8*h_half - 4*(h0 + h1) + 2*a2)
+// a1 = h1 - h0 - (a2 + a3)

--- a/crates/sumcheck/src/prove.rs
+++ b/crates/sumcheck/src/prove.rs
@@ -6,7 +6,7 @@ use p3_field::{ExtensionField, Field, TwoAdicField};
 use rayon::prelude::*;
 use tracing::instrument;
 use utils::{
-    batch_fold_multilinear_in_large_field, batch_fold_multilinear_in_small_field,
+    add_multilinears, batch_fold_multilinear_in_large_field, batch_fold_multilinear_in_small_field,
     univariate_selectors,
 };
 use whir_p3::{
@@ -121,83 +121,189 @@ where
 
     let selectors = univariate_selectors::<F>(skips);
 
-    let mut p_evals = Vec::<(F, EF)>::new();
-    let start = if is_zerofier {
-        p_evals.extend((0..1 << skips).map(|i| (F::from_usize(i), EF::ZERO)));
-        1 << skips
-    } else {
-        0
-    };
-    for z in start..=comp_degree * ((1 << skips) - 1) {
-        let sum_z = if z == (1 << skips) - 1 {
-            if let Some(eq_factor) = eq_factor {
-                (*sum
-                    - (0..(1 << skips) - 1)
-                        .map(|i| p_evals[i].1 * selectors[i].evaluate(eq_factor[round]))
-                        .sum::<EF>())
-                    / selectors[(1 << skips) - 1].evaluate(eq_factor[round])
-            } else {
-                *sum - p_evals.iter().map(|(_, s)| *s).sum::<EF>()
+    match (skips, comp_degree, is_zerofier) {
+        (1, 2, false) => {
+            //  Use {0, 1, 1/2} instead of {0, 1, 2} for classic sumcheck
+            // Instead of evaluating h(z) at z = 0, 1, 2, we evaluate at z = 0, 1, 1/2.
+            // This optimization exploits the symmetry of Lagrange interpolation:
+            //
+            // eq(1/2, 0) = 1/2 * 0 + (1 - 1/2) * 1 = 1/2
+            // eq(1/2, 1) = 1/2 * 1 + 0 * 1/2 = 1/2
+            //
+            // Since this is symmetric, we can compute h(1/2) more efficiently:
+            // h(1/2) = sum_b p(1/2, b) * q(1/2, b)
+            //        = sum_b (eq(1/2, 0) * p(0, b) + eq(1/2, 1) * p(1, b)) *
+            //              (eq(1/2, 0) * q(0, b) + eq(1/2, 1) * q(1, b))
+            //        = 1/4 * sum_b (p(0, b) + p(1, b)) * (q(0, b) + q(1, b))
+            //
+            //  We only need 1 multiplication per hypercube element instead of 3
+
+            // Calculate h(0) - evaluate at z = 0
+            let folded_0 = batch_fold_multilinear_in_small_field(
+                multilinears,
+                &selectors
+                    .iter()
+                    .map(|s| s.evaluate(F::ZERO))
+                    .collect::<Vec<_>>(),
+            );
+            let mut h0 =
+                compute_over_hypercube(&folded_0, computation, batching_scalars, eq_mle.as_ref());
+            if let Some(missing_mul_factor) = missing_mul_factor {
+                h0 *= *missing_mul_factor;
             }
-        } else {
+
+            // Calculate h(1/2) using the mathematical optimization
+            // Instead of evaluating at z = 1/2 directly, we use the formula:
+            // h(1/2) = 1/4 * sum_b (p(0, b) + p(1, b)) * (q(0, b) + q(1, b))
+            let folded_1 = batch_fold_multilinear_in_small_field(
+                multilinears,
+                &selectors
+                    .iter()
+                    .map(|s| s.evaluate(F::ONE))
+                    .collect::<Vec<_>>(),
+            );
+
+            // Add the folded polynomials element-wise: (p(0, b) + p(1, b))
+            let summed_multilinears = folded_0
+                .iter()
+                .zip(folded_1.iter())
+                .map(|(p0, p1)| add_multilinears(p0, p1))
+                .collect::<Vec<_>>();
+
+            // Compute sum over hypercube and multiply by 1/4
+            let mut h_half = compute_over_hypercube(
+                &summed_multilinears,
+                computation,
+                batching_scalars,
+                eq_mle.as_ref(),
+            );
+            h_half *= EF::from(F::ONE.halve()).square();
+            if let Some(missing_mul_factor) = missing_mul_factor {
+                h_half *= *missing_mul_factor;
+            }
+
+            // Derive h(1) from the total sum constraint
+            // Since h(0) + h(1) = total_sum, we have h(1) = total_sum - h(0)
+            let h1 = *sum - h0;
+
+            // Send h(0), h(1), and h(1/2) directly instead of polynomial coefficients
+            fs_prover.add_extension_scalars(&[h0, h1, h_half]);
+
+            // Reconstruct polynomial using Lagrange interpolation over {0, 1, 1/2}
+            // This gives us the same polynomial that would result from evaluating at {0, 1, 2}
+            let p = WhirDensePolynomial::lagrange_interpolation(&[
+                (F::ZERO, h0),
+                (F::ONE, h1),
+                (F::ONE.halve(), h_half),
+            ])
+            .unwrap();
+
+            let challenge = fs_prover.sample();
+            challenges.push(challenge);
+            *sum = p.evaluate(challenge);
+
+            *n_vars -= skips;
+            let pow_bits = grinding.pow_bits::<EF>(
+                (comp_degree + usize::from(eq_factor.is_some())) * ((1 << skips) - 1),
+            );
+            fs_prover.pow_grinding(pow_bits);
+
             let folding_scalars = selectors
                 .iter()
-                .map(|s| s.evaluate(F::from_usize(z)))
+                .map(|s| s.evaluate(challenge))
                 .collect::<Vec<_>>();
-            // If skips == 1 (ie classic sumcheck round, we could avoid 1 multiplication below: TODO not urgent)
-            let folded = batch_fold_multilinear_in_small_field(multilinears, &folding_scalars);
-            let mut sum_z =
-                compute_over_hypercube(&folded, computation, batching_scalars, eq_mle.as_ref());
-            if let Some(missing_mul_factor) = missing_mul_factor {
-                sum_z *= *missing_mul_factor;
+            if let Some(eq_factor) = eq_factor {
+                *missing_mul_factor = Some(
+                    selectors
+                        .iter()
+                        .map(|s| s.evaluate(eq_factor[round]) * s.evaluate(challenge))
+                        .sum::<EF>()
+                        * missing_mul_factor.unwrap_or(EF::ONE),
+                );
+            }
+            batch_fold_multilinear_in_large_field(multilinears, &folding_scalars)
+        }
+        _ => {
+            // Original logic for other cases
+            let mut p_evals = Vec::<(F, EF)>::new();
+            let start = if is_zerofier {
+                p_evals.extend((0..1 << skips).map(|i| (F::from_usize(i), EF::ZERO)));
+                1 << skips
+            } else {
+                0
+            };
+
+            for z in start..=comp_degree * ((1 << skips) - 1) {
+                let sum_z = if z == (1 << skips) - 1 {
+                    if let Some(eq_factor) = eq_factor {
+                        (*sum
+                            - (0..(1 << skips) - 1)
+                                .map(|i| p_evals[i].1 * selectors[i].evaluate(eq_factor[round]))
+                                .sum::<EF>())
+                            / selectors[(1 << skips) - 1].evaluate(eq_factor[round])
+                    } else {
+                        *sum - p_evals.iter().map(|(_, s)| *s).sum::<EF>()
+                    }
+                } else {
+                    let folded = batch_fold_multilinear_in_small_field(
+                        multilinears,
+                        &selectors
+                            .iter()
+                            .map(|s| s.evaluate(F::from_usize(z)))
+                            .collect::<Vec<_>>(),
+                    );
+                    let mut sum_z = compute_over_hypercube(
+                        &folded,
+                        computation,
+                        batching_scalars,
+                        eq_mle.as_ref(),
+                    );
+                    if let Some(missing_mul_factor) = missing_mul_factor {
+                        sum_z *= *missing_mul_factor;
+                    }
+                    sum_z
+                };
+                p_evals.push((F::from_usize(z), sum_z));
             }
 
-            sum_z
-        };
+            let mut p = WhirDensePolynomial::lagrange_interpolation(&p_evals).unwrap();
+            if let Some(eq_factor) = &eq_factor {
+                p *= &WhirDensePolynomial::lagrange_interpolation(
+                    &(0..1 << skips)
+                        .into_par_iter()
+                        .map(|i| (F::from_usize(i), selectors[i].evaluate(eq_factor[round])))
+                        .collect::<Vec<_>>(),
+                )
+                .unwrap();
+            }
 
-        p_evals.push((F::from_usize(z), sum_z));
-    }
+            fs_prover.add_extension_scalars(&p.coeffs);
+            let challenge = fs_prover.sample();
+            challenges.push(challenge);
+            *sum = p.evaluate(challenge);
 
-    let mut p = WhirDensePolynomial::lagrange_interpolation(&p_evals).unwrap();
+            *n_vars -= skips;
+            let pow_bits = grinding.pow_bits::<EF>(
+                (comp_degree + usize::from(eq_factor.is_some())) * ((1 << skips) - 1),
+            );
+            fs_prover.pow_grinding(pow_bits);
 
-    if let Some(eq_factor) = &eq_factor {
-        // https://eprint.iacr.org/2024/108.pdf Section 3.2
-        // We do not take advantage of this trick to send less data, but we could do so in the future (TODO)
-        p *= &WhirDensePolynomial::lagrange_interpolation(
-            &(0..1 << skips)
-                .into_par_iter()
-                .map(|i| (F::from_usize(i), selectors[i].evaluate(eq_factor[round])))
-                .collect::<Vec<_>>(),
-        )
-        .unwrap();
-    }
-
-    fs_prover.add_extension_scalars(&p.coeffs);
-
-    let challenge = fs_prover.sample();
-    challenges.push(challenge);
-    *sum = p.evaluate(challenge);
-    *n_vars -= skips;
-
-    let pow_bits = grinding
-        .pow_bits::<EF>((comp_degree + usize::from(eq_factor.is_some())) * ((1 << skips) - 1));
-    fs_prover.pow_grinding(pow_bits);
-
-    let folding_scalars = selectors
-        .iter()
-        .map(|s| s.evaluate(challenge))
-        .collect::<Vec<_>>();
-    if let Some(eq_factor) = eq_factor {
-        *missing_mul_factor = Some(
-            selectors
+            let folding_scalars = selectors
                 .iter()
-                .map(|s| s.evaluate(eq_factor[round]) * s.evaluate(challenge))
-                .sum::<EF>()
-                * missing_mul_factor.unwrap_or(EF::ONE),
-        );
+                .map(|s| s.evaluate(challenge))
+                .collect::<Vec<_>>();
+            if let Some(eq_factor) = eq_factor {
+                *missing_mul_factor = Some(
+                    selectors
+                        .iter()
+                        .map(|s| s.evaluate(eq_factor[round]) * s.evaluate(challenge))
+                        .sum::<EF>()
+                        * missing_mul_factor.unwrap_or(EF::ONE),
+                );
+            }
+            batch_fold_multilinear_in_large_field(multilinears, &folding_scalars)
+        }
     }
-    // If skips == 1 (ie classic sumcheck round, we could avoid 1 multiplication below: TODO not urgent)
-    batch_fold_multilinear_in_large_field(multilinears, &folding_scalars)
 }
 
 fn compute_over_hypercube<F, NF, EF, SC>(

--- a/crates/sumcheck/src/prove.rs
+++ b/crates/sumcheck/src/prove.rs
@@ -131,14 +131,30 @@ where
             // eq(1/2, 1) = 1/2 * 1 + 0 * 1/2 = 1/2
             //
             // Since this is symmetric, we can compute h(1/2) more efficiently:
-            // h(1/2) = sum_b p(1/2, b) * q(1/2, b)
-            //        = sum_b (eq(1/2, 0) * p(0, b) + eq(1/2, 1) * p(1, b)) *
-            //              (eq(1/2, 0) * q(0, b) + eq(1/2, 1) * q(1, b))
-            //        = 1/4 * sum_b (p(0, b) + p(1, b)) * (q(0, b) + q(1, b))
+            // h(1/2) = ∑_b f(1/2, b)
+            //        = ∑_b (eq(1/2, 0) * f(0, b) + eq(1/2, 1) * f(1, b))
+            //        = ∑_b (1/2 * f(0, b) + 1/2 * f(1, b))
+            //        = 1/4 * ∑_b (f(0, b) + f(1, b))
             //
-            //  We only need 1 multiplication per hypercube element instead of 3
+            //  We only need 1 evaluation per hypercube element instead of 3
 
             // Calculate h(0) - evaluate at z = 0
+            let h0 = {
+                let folding_scalars: Vec<_> =
+                    selectors.iter().map(|s| s.evaluate(F::ZERO)).collect();
+                let folded = batch_fold_multilinear_in_small_field(multilinears, &folding_scalars);
+                let mut h =
+                    compute_over_hypercube(&folded, computation, batching_scalars, eq_mle.as_ref());
+                if let Some(missing_mul_factor) = missing_mul_factor {
+                    h *= *missing_mul_factor;
+                }
+                h
+            };
+
+            // Derive h(1) from the constraint: h(1) = total_sum - h(0)
+            let h1 = *sum - h0;
+
+            // Fold multilinears at z = 0 to get f(0, b) for all b
             let folded_0 = batch_fold_multilinear_in_small_field(
                 multilinears,
                 &selectors
@@ -146,15 +162,7 @@ where
                     .map(|s| s.evaluate(F::ZERO))
                     .collect::<Vec<_>>(),
             );
-            let mut h0 =
-                compute_over_hypercube(&folded_0, computation, batching_scalars, eq_mle.as_ref());
-            if let Some(missing_mul_factor) = missing_mul_factor {
-                h0 *= *missing_mul_factor;
-            }
-
-            // Calculate h(1/2) using the mathematical optimization
-            // Instead of evaluating at z = 1/2 directly, we use the formula:
-            // h(1/2) = 1/4 * sum_b (p(0, b) + p(1, b)) * (q(0, b) + q(1, b))
+            // Fold multilinears at z = 1 to get f(1, b) for all b
             let folded_1 = batch_fold_multilinear_in_small_field(
                 multilinears,
                 &selectors
@@ -163,14 +171,14 @@ where
                     .collect::<Vec<_>>(),
             );
 
-            // Add the folded polynomials element-wise: (p(0, b) + p(1, b))
-            let summed_multilinears = folded_0
+            // Sum f(0, b) + f(1, b) for all b
+            let summed_multilinears: Vec<_> = folded_0
                 .iter()
                 .zip(folded_1.iter())
-                .map(|(p0, p1)| add_multilinears(p0, p1))
-                .collect::<Vec<_>>();
+                .map(|(f0, f1)| add_multilinears(f0, f1))
+                .collect();
 
-            // Compute sum over hypercube and multiply by 1/4
+            // Apply the optimization: h(1/2) = 1/4 * ∑_b (f(0, b) + f(1, b))
             let mut h_half = compute_over_hypercube(
                 &summed_multilinears,
                 computation,
@@ -182,15 +190,17 @@ where
                 h_half *= *missing_mul_factor;
             }
 
-            // Derive h(1) from the total sum constraint
-            // Since h(0) + h(1) = total_sum, we have h(1) = total_sum - h(0)
-            let h1 = *sum - h0;
+            // Verify that our derivation is correct: h(0) + h(1) should equal total_sum
+            // Since h(1) = total_sum - h(0), this should always be zero
+            // TODO: check if we can remove this check
+            // debug_assert!(
+            //     (h0 + h1 - *sum).is_zero(),
+            //     "Derivation error: h(0) + h(1) != total_sum"
+            // );
 
             // Send h(0), h(1), and h(1/2) directly instead of polynomial coefficients
             fs_prover.add_extension_scalars(&[h0, h1, h_half]);
 
-            // Reconstruct polynomial using Lagrange interpolation over {0, 1, 1/2}
-            // This gives us the same polynomial that would result from evaluating at {0, 1, 2}
             let p = WhirDensePolynomial::lagrange_interpolation(&[
                 (F::ZERO, h0),
                 (F::ONE, h1),
@@ -208,10 +218,7 @@ where
             );
             fs_prover.pow_grinding(pow_bits);
 
-            let folding_scalars = selectors
-                .iter()
-                .map(|s| s.evaluate(challenge))
-                .collect::<Vec<_>>();
+            let folding_scalars: Vec<_> = selectors.iter().map(|s| s.evaluate(challenge)).collect();
             if let Some(eq_factor) = eq_factor {
                 *missing_mul_factor = Some(
                     selectors

--- a/crates/sumcheck/src/prove.rs
+++ b/crates/sumcheck/src/prove.rs
@@ -2,7 +2,7 @@ use std::{any::TypeId, borrow::Borrow};
 
 use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{BasedVectorSpace, PackedValue};
-use p3_field::{ExtensionField, Field, TwoAdicField};
+use p3_field::{ExtensionField, Field, PrimeField64, TwoAdicField};
 use rayon::prelude::*;
 use tracing::instrument;
 use utils::{
@@ -15,6 +15,9 @@ use whir_p3::{
 };
 
 use crate::{SumcheckComputation, SumcheckComputationPacked, SumcheckGrinding};
+
+const FIELD_HALF_U32: u32 = 1065353217; // 1/2 in KoalaBear
+const FIELD_QUARTER_U32: u32 = 1598029825; // 1/4 in KoalaBear  
 
 pub const MIN_VARS_FOR_GPU: usize = 0; // When there are a small number of variables, it's not worth using GPU
 
@@ -34,7 +37,7 @@ pub fn prove<F, NF, EF, M, SC, Challenger>(
     mut missing_mul_factor: Option<EF>,
 ) -> (Vec<EF>, Vec<EvaluationsList<EF>>, EF)
 where
-    F: TwoAdicField,
+    F: TwoAdicField + PrimeField64,
     NF: ExtensionField<F>,
     EF: ExtensionField<NF> + ExtensionField<F> + TwoAdicField,
     M: Borrow<EvaluationsList<NF>>,
@@ -111,7 +114,7 @@ pub fn sc_round<F, NF, EF, SC, Challenger>(
     missing_mul_factor: &mut Option<EF>,
 ) -> Vec<EvaluationsList<EF>>
 where
-    F: TwoAdicField,
+    F: TwoAdicField + PrimeField64,
     NF: ExtensionField<F>,
     EF: ExtensionField<NF> + ExtensionField<F> + TwoAdicField,
     SC: SumcheckComputation<F, NF, EF> + SumcheckComputationPacked<F, EF>,
@@ -185,7 +188,7 @@ where
                 batching_scalars,
                 eq_mle.as_ref(),
             );
-            h_half *= EF::from(F::ONE.halve()).square();
+            h_half *= EF::from(F::from_u32(FIELD_QUARTER_U32));
             if let Some(missing_mul_factor) = missing_mul_factor {
                 h_half *= *missing_mul_factor;
             }
@@ -204,7 +207,7 @@ where
             let p = WhirDensePolynomial::lagrange_interpolation(&[
                 (F::ZERO, h0),
                 (F::ONE, h1),
-                (F::ONE.halve(), h_half),
+                (F::from_u32(FIELD_HALF_U32), h_half),
             ])
             .unwrap();
 

--- a/crates/sumcheck/src/verify.rs
+++ b/crates/sumcheck/src/verify.rs
@@ -8,8 +8,6 @@ use whir_p3::{
 
 use crate::SumcheckGrinding;
 
-const FIELD_HALF_U32: u32 = 1065353217; // 1/2 in KoalaBear
-
 #[derive(Debug, Clone)]
 pub enum SumcheckError {
     Fs(ProofError),
@@ -89,28 +87,10 @@ where
     for (&deg, sumation_set) in max_degree_per_vars.iter().zip(sumation_sets) {
         let (pol, computed_sum) = match (deg, sumation_set.len()) {
             (2, 2) if sumation_set[0] == EF::ZERO && sumation_set[1] == EF::ONE => {
-                // The prover sent h(0), h(1), and h(1/2) directly instead of polynomial
-                // coefficients. We reconstruct the polynomial using Lagrange interpolation
-                // over these three points, which gives us the same result as evaluating
-                // at {0, 1, 2} but with better performance.
-
-                // Receive h(0), h(1), and h(1/2) directly from the prover
-                let h_values = verifier_state.next_extension_scalars_vec(3)?;
-                let [h0, h1, h_half] = h_values.as_slice() else {
-                    return Err(SumcheckError::InvalidRound);
-                };
-
-                // Reconstruct polynomial using Lagrange interpolation over {0, 1, 1/2}
-                let p_evals = [
-                    (EF::ZERO, *h0),
-                    (EF::ONE, *h1),
-                    (EF::from_u32(FIELD_HALF_U32), *h_half),
-                ];
-                let pol = WhirDensePolynomial::lagrange_interpolation(&p_evals).unwrap();
-
-                // Compute sum over the summation set {0, 1} to verify the round
+                // Case for the optimized sumcheck using {0,1/2,1} as evaluation points.
+                let coeffs = verifier_state.next_extension_scalars_vec(3)?;
+                let pol = WhirDensePolynomial::from_coefficients_vec(coeffs);
                 let computed_sum = sumation_set.iter().map(|&s| pol.evaluate(s)).sum();
-
                 (pol, computed_sum)
             }
             _ => {

--- a/crates/sumcheck/src/verify.rs
+++ b/crates/sumcheck/src/verify.rs
@@ -85,10 +85,37 @@ where
     let (mut sum, mut target) = (EF::ZERO, EF::ZERO);
 
     for (&deg, sumation_set) in max_degree_per_vars.iter().zip(sumation_sets) {
-        let coeffs = verifier_state.next_extension_scalars_vec(deg + 1)?;
-        let pol = WhirDensePolynomial::from_coefficients_vec(coeffs);
+        let (pol, computed_sum) = match (deg, sumation_set.len()) {
+            (2, 2) if sumation_set[0] == EF::ZERO && sumation_set[1] == EF::ONE => {
+                // The prover sent h(0), h(1), and h(1/2) directly instead of polynomial
+                // coefficients. We reconstruct the polynomial using Lagrange interpolation
+                // over these three points, which gives us the same result as evaluating
+                // at {0, 1, 2} but with better performance.
 
-        let computed_sum = sumation_set.iter().map(|&s| pol.evaluate(s)).sum();
+                // Receive h(0), h(1), and h(1/2) directly from the prover
+                let h_values = verifier_state.next_extension_scalars_vec(3)?;
+                let h0 = h_values[0];
+                let h1 = h_values[1];
+                let h_half = h_values[2];
+
+                // Reconstruct polynomial using Lagrange interpolation over {0, 1, 1/2}
+                let p_evals = vec![(EF::ZERO, h0), (EF::ONE, h1), (EF::ONE.halve(), h_half)];
+                let pol = WhirDensePolynomial::lagrange_interpolation(&p_evals).unwrap();
+
+                // Compute sum over the summation set {0, 1} to verify the round
+                let computed_sum = sumation_set.iter().map(|&s| pol.evaluate(s)).sum();
+
+                (pol, computed_sum)
+            }
+            _ => {
+                // Standard case: receive coefficients and create polynomial
+                let coeffs = verifier_state.next_extension_scalars_vec(deg + 1)?;
+                let pol = WhirDensePolynomial::from_coefficients_vec(coeffs);
+                let computed_sum = sumation_set.iter().map(|&s| pol.evaluate(s)).sum();
+                (pol, computed_sum)
+            }
+        };
+
         if first_round {
             first_round = false;
             sum = computed_sum;

--- a/crates/sumcheck/src/verify.rs
+++ b/crates/sumcheck/src/verify.rs
@@ -8,6 +8,8 @@ use whir_p3::{
 
 use crate::SumcheckGrinding;
 
+const FIELD_HALF_U32: u32 = 1065353217; // 1/2 in KoalaBear
+
 #[derive(Debug, Clone)]
 pub enum SumcheckError {
     Fs(ProofError),
@@ -99,7 +101,11 @@ where
                 };
 
                 // Reconstruct polynomial using Lagrange interpolation over {0, 1, 1/2}
-                let p_evals = [(EF::ZERO, *h0), (EF::ONE, *h1), (EF::ONE.halve(), *h_half)];
+                let p_evals = [
+                    (EF::ZERO, *h0),
+                    (EF::ONE, *h1),
+                    (EF::from_u32(FIELD_HALF_U32), *h_half),
+                ];
                 let pol = WhirDensePolynomial::lagrange_interpolation(&p_evals).unwrap();
 
                 // Compute sum over the summation set {0, 1} to verify the round

--- a/crates/sumcheck/src/verify.rs
+++ b/crates/sumcheck/src/verify.rs
@@ -94,12 +94,12 @@ where
 
                 // Receive h(0), h(1), and h(1/2) directly from the prover
                 let h_values = verifier_state.next_extension_scalars_vec(3)?;
-                let h0 = h_values[0];
-                let h1 = h_values[1];
-                let h_half = h_values[2];
+                let [h0, h1, h_half] = h_values.as_slice() else {
+                    return Err(SumcheckError::InvalidRound);
+                };
 
                 // Reconstruct polynomial using Lagrange interpolation over {0, 1, 1/2}
-                let p_evals = vec![(EF::ZERO, h0), (EF::ONE, h1), (EF::ONE.halve(), h_half)];
+                let p_evals = [(EF::ZERO, *h0), (EF::ONE, *h1), (EF::ONE.halve(), *h_half)];
                 let pol = WhirDensePolynomial::lagrange_interpolation(&p_evals).unwrap();
 
                 // Compute sum over the summation set {0, 1} to verify the round

--- a/src/examples/poseidon2.rs
+++ b/src/examples/poseidon2.rs
@@ -88,6 +88,16 @@ pub fn prove_poseidon2(
     n_preprocessed_columns: usize,
     display_logs: bool,
 ) -> Poseidon2Benchmark {
+    prove_poseidon2_with_seed(log_n_rows, settings, n_preprocessed_columns, display_logs, 0)
+}
+
+pub fn prove_poseidon2_with_seed(
+    log_n_rows: usize,
+    settings: AirSettings,
+    n_preprocessed_columns: usize,
+    display_logs: bool,
+    seed: u64,
+) -> Poseidon2Benchmark {
     if display_logs {
         let env_filter = EnvFilter::builder()
             .with_default_directive(LevelFilter::INFO.into())
@@ -101,7 +111,7 @@ pub fn prove_poseidon2(
 
     let n_rows = 1 << log_n_rows;
 
-    let mut rng = StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(seed);
     let constants =
         RoundConstants::<F, WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>::from_rng(&mut rng);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod examples;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,7 @@ use whir_p3::parameters::{FoldingFactor, errors::SecurityAssumption};
 
 use crate::examples::poseidon2::prove_poseidon2;
 
-const SECURITY_BITS: usize = 32; // I changed this to lower the variation in grinding
-
+const SECURITY_BITS: usize = 128;
 fn main() {
     let (log_n_rows, log_inv_rate) = (18, 1);
     let benchmark = prove_poseidon2(

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use whir_p3::parameters::{FoldingFactor, errors::SecurityAssumption};
 
 use crate::examples::poseidon2::prove_poseidon2;
 
-const SECURITY_BITS: usize = 128;
+const SECURITY_BITS: usize = 32; // I changed this to lower the variation in grinding
 
 fn main() {
     let (log_n_rows, log_inv_rate) = (18, 1);


### PR DESCRIPTION
This PR implements [this issue](https://github.com/tcoratger/whir-p3/issues/234) mentioned by Giacomo Fenzi. Instead of evaluating the round polynomial h(z) at points {0, 1, 2}, this implementation now uses {0, 1, 1/2}.
This reduces the number of multiplications in the hypercube sum. The explanation can be found in the issue


### Benchmark results

|  | Old Version | This PR | Δ (%) | Δ (abs) |
|---|-----------:|--------:|------:|--------:|
| inner_only | 30.81 ms | 37.82 ms | +22.77% | +7.01 ms |
| zerocheck_only | 1.3027 s | 1.3083 s | +0.42% | +0.0055 s |
| poseidon2_protocol | 6.65 s | 8.68 s | +30.56% | +2.03 s |


Despite switching the round evaluations from {0,1,2} to {0,1,1/2}, timings did not improve; Inner-only even regressed (+23%) and end-to-end increased (+30%).


#### Notes

The benches were made under the  following configuration

- Sumcheck PoW/grinding (disabled in benches)
  - Benches pass `security_bits = 0` via `AirSettings::new(0, ...)`, which 
- WHIR/PCS grinding
  - Controlled by `crates/air/src/lib.rs`: `const WHIR_POW_BITS: usize = 0` 
